### PR TITLE
 add testcase »(un)marshal long scalar values«

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,11 @@ classes
 
 # files
 *.iml
+
+# Eclipse (Scala IDE) artifacts
+.classpath
+.project
+.settings
+.cache-main
+.cache-tests
+bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
  language: scala
  scala:
-   - 2.11.8
-   - 2.12.1
+   - 2.11.11
+   - 2.12.3
  jdk:
    - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ scalacOptions ++= {
 
 libraryDependencies ++= Seq(
   "org.sangria-graphql" %% "sangria-marshalling-api" % "1.0.0",
-  "org.scalatest" %% "scalatest" % "3.0.1"
+  "org.scalatest" %% "scalatest" % "3.0.3"
 )
 
 git.remoteRepo := "git@github.com:sangria-graphql/sangria-marshalling-testkit.git"

--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,8 @@ description := "Sangria Marshalling API TestKit"
 homepage := Some(url("http://sangria-graphql.org"))
 licenses := Seq("Apache License, ASL Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 
-scalaVersion := "2.12.1"
-crossScalaVersions := Seq("2.11.8", "2.12.1")
+scalaVersion := "2.12.3"
+crossScalaVersions := Seq("2.11.11", "2.12.3")
 
 scalacOptions ++= Seq("-deprecation", "-feature")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.16

--- a/src/main/scala/sangria/marshalling/testkit/MarshallingBehaviour.scala
+++ b/src/main/scala/sangria/marshalling/testkit/MarshallingBehaviour.scala
@@ -50,6 +50,26 @@ trait MarshallingBehaviour {
       iu.isListNode(marshaled) should be (false)
     }
 
+    "(un)marshal long scalar values" in {
+      val marshaled = rm.scalarNode(Long.MaxValue, "Test", Set.empty)
+
+      val scalar = iu.getScalarValue(marshaled)
+      val scalaScalar = iu.getScalaScalarValue(marshaled)
+
+      iu.getScalaScalarValue(marshaled) should be (Long.MaxValue: Any)
+
+      if (scalar != scalaScalar)
+        scalar should be (marshaled)
+
+      iu.isScalarNode(marshaled) should be (true)
+      iu.isDefined(marshaled) should be (true)
+
+      iu.isEnumNode(marshaled) should be (false)
+      iu.isVariableNode(marshaled) should be (false)
+      iu.isMapNode(marshaled) should be (false)
+      iu.isListNode(marshaled) should be (false)
+    }
+
     "(un)marshal big int scalar values" in {
       val marshaled = rm.scalarNode(BigInt("12323432432432"), "Test", Set.empty)
 


### PR DESCRIPTION
Coverage was missing for `playJson.scala`:
```
25     def scalarNode(value: Any, typeName: String, info: Set[ScalarValueInfo]) = value match {
⋮
30       case v: Long ⇒ JsNumber(BigDecimal(v))
⋮
36     }
```