### PR TITLE
Updates for Scala 2.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
  language: scala
  scala:
    - 2.11.11
-   - 2.12.8
+   - 2.12.10
    - 2.13.0
  jdk:
    - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
  language: scala
  scala:
    - 2.11.11
-   - 2.12.3
+   - 2.12.8
+   - 2.13.0
  jdk:
    - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@
    - 2.12.10
    - 2.13.0
  jdk:
-   - oraclejdk8
+   - openjdk8

--- a/build.sbt
+++ b/build.sbt
@@ -1,26 +1,26 @@
 name := "sangria-marshalling-testkit"
 organization := "org.sangria-graphql"
-version := "1.0.2-SNAPSHOT"
+version := "1.0.3-SNAPSHOT"
 
 description := "Sangria Marshalling API TestKit"
 homepage := Some(url("http://sangria-graphql.org"))
 licenses := Seq("Apache License, ASL Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 
-scalaVersion := "2.12.3"
-crossScalaVersions := Seq("2.11.11", "2.12.3")
+scalaVersion := "2.13.0"
+crossScalaVersions := Seq("2.11.11", "2.12.8", scalaVersion.value)
 
 scalacOptions ++= Seq("-deprecation", "-feature")
 
 scalacOptions ++= {
-  if (scalaVersion.value startsWith "2.12")
-    Seq.empty
-  else
+  if (scalaVersion.value startsWith "2.11")
     Seq("-target:jvm-1.7")
+  else
+    Seq.empty
 }
 
 libraryDependencies ++= Seq(
-  "org.sangria-graphql" %% "sangria-marshalling-api" % "1.0.0",
-  "org.scalatest" %% "scalatest" % "3.0.4"
+  "org.sangria-graphql" %% "sangria-marshalling-api" % "2.0.0-SNAPSHOT",
+  "org.scalatest" %% "scalatest" % "3.0.8"
 )
 
 git.remoteRepo := "git@github.com:sangria-graphql/sangria-marshalling-testkit.git"

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ homepage := Some(url("http://sangria-graphql.org"))
 licenses := Seq("Apache License, ASL Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 
 scalaVersion := "2.13.0"
-crossScalaVersions := Seq("2.11.11", "2.12.8", scalaVersion.value)
+crossScalaVersions := Seq("2.11.11", "2.12.10", scalaVersion.value)
 
 scalacOptions ++= Seq("-deprecation", "-feature")
 

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ scalacOptions ++= {
 }
 
 libraryDependencies ++= Seq(
-  "org.sangria-graphql" %% "sangria-marshalling-api" % "2.0.0-SNAPSHOT",
+  "org.sangria-graphql" %% "sangria-marshalling-api" % "1.0.4-SNAPSHOT",
   "org.scalatest" %% "scalatest" % "3.0.8"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 name := "sangria-marshalling-testkit"
 organization := "org.sangria-graphql"
 version := "1.0.3-SNAPSHOT"
+mimaPreviousArtifacts := Set("org.sangria-graphql" %% "sangria-marshalling-testkit" % "1.0.1")
 
 description := "Sangria Marshalling API TestKit"
 homepage := Some(url("http://sangria-graphql.org"))

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "sangria-marshalling-testkit"
 organization := "org.sangria-graphql"
-version := "1.0.3-SNAPSHOT"
+version := "1.0.2-SNAPSHOT"
 mimaPreviousArtifacts := Set("org.sangria-graphql" %% "sangria-marshalling-testkit" % "1.0.1")
 
 description := "Sangria Marshalling API TestKit"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.2.8

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
-resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
+resolvers += "jgit-repo" at "https://download.eclipse.org/jgit/maven"
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.4")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")

--- a/src/main/scala/sangria/marshalling/testkit/InputHandlingBehaviour.scala
+++ b/src/main/scala/sangria/marshalling/testkit/InputHandlingBehaviour.scala
@@ -4,7 +4,7 @@ import org.scalatest.{WordSpec, Matchers}
 import sangria.marshalling._
 
 trait InputHandlingBehaviour {
-  this: WordSpec with Matchers ⇒
+  this: WordSpec with Matchers =>
 
   def `AST-based input marshaller`[Raw](rm: ResultMarshaller)(implicit ti: ToInput[rm.Node, Raw]): Unit = {
     "handle undefined values (ast-based marshalling)" in {
@@ -106,8 +106,8 @@ trait InputHandlingBehaviour {
 
   private def marshalUndefined(rm: ResultMarshaller): rm.Node =
     rm.mapNode(Seq(
-      "title" → rm.scalarNode("Foo", "Test", Set.empty),
-      "comments" → rm.arrayNode(Vector.empty)
+      "title" -> rm.scalarNode("Foo", "Test", Set.empty),
+      "comments" -> rm.arrayNode(Vector.empty)
     ))
 
   private def verifyUndefined[T](res: T, m: ResultMarshaller)(implicit iu: InputUnmarshaller[T]): Unit = {
@@ -142,22 +142,22 @@ trait InputHandlingBehaviour {
   }
 
   def assertPossibleNullNodes[T](res: T, m: ResultMarshaller, names: Seq[String])(implicit iu: InputUnmarshaller[T]) =
-    names.foreach { name ⇒
+    names.foreach { name =>
       if (iu.getMapKeys(res).exists(_ == name))
         iu.getMapValue(res, name) should be (Some(m.nullNode))
     }
 
   private def marshalNull(rm: ResultMarshaller): rm.Node =
     rm.mapNode(Seq(
-      "title" → rm.scalarNode("Foo", "Test", Set.empty),
-      "text" → rm.nullNode,
-      "tags" → rm.nullNode,
-      "comments" → rm.arrayNode(Vector(
+      "title" -> rm.scalarNode("Foo", "Test", Set.empty),
+      "text" -> rm.nullNode,
+      "tags" -> rm.nullNode,
+      "comments" -> rm.arrayNode(Vector(
         rm.mapNode(List(
-          "author" → rm.scalarNode("bob", "Test", Set.empty))),
+          "author" -> rm.scalarNode("bob", "Test", Set.empty))),
         rm.mapNode(List(
-          "author" → rm.scalarNode("bob1", "Test", Set.empty),
-          "text" → rm.nullNode))
+          "author" -> rm.scalarNode("bob1", "Test", Set.empty),
+          "text" -> rm.nullNode))
       ))
     ))
 
@@ -168,20 +168,20 @@ trait InputHandlingBehaviour {
     iu.getMapValue(res, "text") should be (Some(m.nullNode))
     iu.getMapValue(res, "tags") should be (Some(m.nullNode))
     iu.getMapValue(res, "comments") should be (Some(m.arrayNode(Vector(
-      m.mapNode(Vector("author" → m.scalarNode("bob", "Test", Set.empty))),
-      m.mapNode(Vector("author" → m.scalarNode("bob1", "Test", Set.empty), "text" → m.nullNode))
+      m.mapNode(Vector("author" -> m.scalarNode("bob", "Test", Set.empty))),
+      m.mapNode(Vector("author" -> m.scalarNode("bob1", "Test", Set.empty), "text" -> m.nullNode))
     ))))
   }
 
   private def marshalDefined(rm: ResultMarshaller): rm.Node =
     rm.mapNode(Seq(
-      "title" → rm.scalarNode("Foo", "Test", Set.empty),
-      "text" → rm.scalarNode("foo bar and baz", "Test", Set.empty),
-      "tags" → rm.arrayNode(Vector(rm.scalarNode("culture", "Test", Set.empty), rm.scalarNode("nature", "Test", Set.empty))),
-      "comments" → rm.arrayNode(Vector(
+      "title" -> rm.scalarNode("Foo", "Test", Set.empty),
+      "text" -> rm.scalarNode("foo bar and baz", "Test", Set.empty),
+      "tags" -> rm.arrayNode(Vector(rm.scalarNode("culture", "Test", Set.empty), rm.scalarNode("nature", "Test", Set.empty))),
+      "comments" -> rm.arrayNode(Vector(
         rm.mapNode(List(
-          "author" → rm.scalarNode("bob", "Test", Set.empty),
-          "text" → rm.scalarNode("first!", "Test", Set.empty)))
+          "author" -> rm.scalarNode("bob", "Test", Set.empty),
+          "text" -> rm.scalarNode("first!", "Test", Set.empty)))
       ))
     ))
 
@@ -192,7 +192,7 @@ trait InputHandlingBehaviour {
     iu.getMapValue(res, "text") should be (Some(m.scalarNode("foo bar and baz", "Test", Set.empty)))
     iu.getMapValue(res, "tags") should be (Some(m.arrayNode(Vector(m.scalarNode("culture", "Test", Set.empty), m.scalarNode("nature", "Test", Set.empty)))))
     iu.getMapValue(res, "comments") should be (Some(m.arrayNode(Vector(
-      m.mapNode(Vector("author" → m.scalarNode("bob", "Test", Set.empty), "text" → m.scalarNode("first!", "Test", Set.empty)))
+      m.mapNode(Vector("author" -> m.scalarNode("bob", "Test", Set.empty), "text" -> m.scalarNode("first!", "Test", Set.empty)))
     ))))
   }
 }

--- a/src/main/scala/sangria/marshalling/testkit/MarshallingBehaviour.scala
+++ b/src/main/scala/sangria/marshalling/testkit/MarshallingBehaviour.scala
@@ -7,7 +7,7 @@ import sangria.marshalling.MarshallingUtil._
 import sangria.util.tag._
 
 trait MarshallingBehaviour {
-  this: WordSpec with Matchers ⇒
+  this: WordSpec with Matchers =>
 
   def `value (un)marshaller`[T](rm: ResultMarshaller)(implicit iu: InputUnmarshaller[rm.Node]): Unit = {
     "(un)marshal boolean scalar values" in {
@@ -202,12 +202,12 @@ trait MarshallingBehaviour {
     "(un)marshal list values" in {
       import sangria.marshalling.scalaMarshalling._
 
-      val map = rm.mapNode(Vector("a" → rm.scalarNode(1, "Test", Set.empty)))
+      val map = rm.mapNode(Vector("a" -> rm.scalarNode(1, "Test", Set.empty)))
       val seq = Vector(map, rm.nullNode, rm.scalarNode("ABC", "Test", Set.empty), rm.arrayNode(Vector.empty))
       val marshaled = rm.arrayNode(seq)
 
       marshaled.convertMarshaled[Any @@ ScalaInput] should be (
-        Vector(Map("a" → 1), null, "ABC", Vector.empty))
+        Vector(Map("a" -> 1), null, "ABC", Vector.empty))
 
       iu.getListValue(marshaled) should be (seq)
 
@@ -223,18 +223,18 @@ trait MarshallingBehaviour {
     "(un)marshal map values" in {
       import sangria.marshalling.scalaMarshalling._
 
-      def map = rm.mapNode(Vector("a" → rm.scalarNode(1, "Test", Set.empty)))
+      def map = rm.mapNode(Vector("a" -> rm.scalarNode(1, "Test", Set.empty)))
       def seq = rm.arrayNode(Vector(map, rm.nullNode, rm.scalarNode("ABC", "Test", Set.empty), rm.arrayNode(Vector.empty)))
 
-      val marshaled1 = rm.mapNode(Vector("first" → seq, "second" → rm.nullNode))
+      val marshaled1 = rm.mapNode(Vector("first" -> seq, "second" -> rm.nullNode))
       val marshaled2 = rm.mapNode(rm.addMapNodeElem(rm.addMapNodeElem(rm.emptyMapNode(Seq("first", "second")), "first", seq, false), "second", rm.nullNode, false))
       val marshaled3 = rm.mapNode(rm.addMapNodeElem(rm.addMapNodeElem(rm.emptyMapNode(Seq("first", "second")), "first", seq, true), "second", rm.nullNode, true))
 
-      List(marshaled1, marshaled2, marshaled3) foreach { marshaled ⇒
+      List(marshaled1, marshaled2, marshaled3) foreach { marshaled =>
         marshaled.convertMarshaled[Any @@ ScalaInput] should be (
           Map(
-            "first" → Vector(Map("a" → 1), null, "ABC", Vector.empty),
-            "second" → null))
+            "first" -> Vector(Map("a" -> 1), null, "ABC", Vector.empty),
+            "second" -> null))
 
         iu.isMapNode(marshaled) should be (true)
         iu.isDefined(marshaled) should be (true)

--- a/src/main/scala/sangria/marshalling/testkit/ParsingBehaviour.scala
+++ b/src/main/scala/sangria/marshalling/testkit/ParsingBehaviour.scala
@@ -6,7 +6,7 @@ import sangria.marshalling.{InputParser, InputUnmarshaller}
 import scala.util.Success
 
 trait ParsingBehaviour {
-  this: WordSpec with Matchers ⇒
+  this: WordSpec with Matchers =>
 
   def `input parser`[T : InputUnmarshaller : InputParser](testSubjects: ParseTestSubjects): Unit = {
     val iu = implicitly[InputUnmarshaller[T]]
@@ -100,7 +100,7 @@ trait ParsingBehaviour {
     }
 
     "result in failure in case of syntax errors" in {
-      testSubjects.syntaxError.foreach { broken ⇒
+      testSubjects.syntaxError.foreach { broken =>
         val result = parser.parse(broken)
 
         result.isFailure should be (true)


### PR DESCRIPTION
Includes @jazott3's commits from #2 but with some additional updates, new MiMa setup for bincompat checking, and some updated versions.

Depends on this PR: https://github.com/sangria-graphql/sangria-marshalling-api/pull/5