### PR TITLE
feat(MarshallingBehaviour)!: allow map to be a scalar

### DIFF
--- a/src/main/scala/sangria/marshalling/testkit/MarshallingBehaviour.scala
+++ b/src/main/scala/sangria/marshalling/testkit/MarshallingBehaviour.scala
@@ -249,7 +249,7 @@ trait MarshallingBehaviour {
         iu.getRootMapValue(marshaled, "non-existing") should be (None)
 
         iu.isListNode(marshaled) should be (false)
-        iu.isScalarNode(marshaled) should be (false)
+        iu.isScalarNode(marshaled) should be (true)
         iu.isEnumNode(marshaled) should be (false)
         iu.isVariableNode(marshaled) should be (false)
       }

--- a/src/main/scala/sangria/marshalling/testkit/MarshallingBehaviour.scala
+++ b/src/main/scala/sangria/marshalling/testkit/MarshallingBehaviour.scala
@@ -171,6 +171,27 @@ trait MarshallingBehaviour {
       iu.isListNode(marshaled) should be (false)
     }
 
+    "(un)marshal map scalar values" in {
+      val map = rm.mapNode(Vector("a" -> rm.scalarNode(1, "TestInt", Set.empty)))
+      val marshaled = rm.scalarNode(map, "TestObject", Set.empty)
+
+      val scalar = iu.getScalarValue(marshaled)
+      val scalaScalar = iu.getScalaScalarValue(marshaled)
+
+      if (scalar != scalaScalar)
+        scalar should be (marshaled)
+
+      scalaScalar should be (Map("a" -> 1))
+
+      iu.isScalarNode(marshaled) should be (true)
+      iu.isDefined(marshaled) should be (true)
+
+      iu.isEnumNode(marshaled) should be (false)
+      iu.isVariableNode(marshaled) should be (false)
+      iu.isMapNode(marshaled) should be (true)
+      iu.isListNode(marshaled) should be (false)
+    }
+
     "(un)marshal enum values" in {
       val marshaled = rm.enumNode("FOO", "Test")
 


### PR DESCRIPTION
please review 🙏 

### Motivation
This PR is a first effort to make federation possible in Sangria, and it comes as a response to the federation issue discussed [here](https://github.com/sangria-graphql/sangria/issues/462).

### Changes
To make federation possible in sangria, there is a need to allow objects (maps) to be scalars. Thus, I changed the contract for the unmarshalling of map values, by making it possible for them to be scalars.

### Consequences
By allowing this change, we are breaking the type safety introduced by the previous contract, because now anywhere a scalar can be passed, an object can be passed too. And, this can lead to potential [security concerns](http://www.petecorey.com/blog/2017/06/12/graphql-nosql-injection-through-json-types/) if not dealt with properly. However, this is necessary to support Apollo federation.
